### PR TITLE
Parse token id through @premia/utils

### DIFF
--- a/core/purchase.ts
+++ b/core/purchase.ts
@@ -1,9 +1,7 @@
-import { eventPurchase, eventForTelegram } from "../models/models";
-import { fixedToNumber } from '@premia/utils'
-import { BigNumber } from 'ethers';
+import { eventForTelegram, eventPurchase } from "../models/models";
+import { fixedToNumber, parseTokenId, TokenType } from '@premia/utils'
 import { bnToNumber, bnToNumberBTC, endpoint } from "../utils/utils";
 import { envConfig } from "../config/env";
-
 
 
 let poolViewContract: any;
@@ -13,10 +11,10 @@ async function sendNotificationETH(data: eventPurchase, http: any) {
       size: data.contractSize,
       pair: `WETH/DAI`
     }
-    const getDecoded = await poolViewContract.methods.getParametersForTokenId(data.longTokenId).call()
-    constructEvent.type = getDecoded[`0`] === `4` ? `long Call` : getDecoded[`0`] === `6` ? `long Put` : `Not Supported`
-    constructEvent.maturity = new Date(getDecoded[`1`] * 1000).toDateString();
-    constructEvent.strikePrice = fixedToNumber(BigNumber.from(getDecoded[`2`]));
+    const {tokenType, maturity, strike64x64} = parseTokenId(data.longTokenId);
+    constructEvent.type = tokenType === TokenType.LongCall ? `long Call` : tokenType === TokenType.LongPut ? `long Put` : `Not Supported`
+    constructEvent.maturity = new Date(maturity.toNumber() * 1000).toDateString();
+    constructEvent.strikePrice = fixedToNumber(strike64x64);
     await http.get(
       `${endpoint}New Purchase ${constructEvent.pair} ${constructEvent.type} size: ${constructEvent.size} strike: ${constructEvent.strikePrice} maturity: ${constructEvent.maturity}`
     )
@@ -42,10 +40,10 @@ async function sendNotificationLINK(data: eventPurchase, http: any) {
       size: data.contractSize,
       pair: `LINK/DAI`
     }
-    const getDecoded = await poolViewContract.methods.getParametersForTokenId(data.longTokenId).call()
-    constructEvent.type = getDecoded[`0`] === `4` ? `long Call` : getDecoded[`0`] === `6` ? `long Put` : `Not Supported`
-    constructEvent.maturity = new Date(getDecoded[`1`] * 1000).toDateString();
-    constructEvent.strikePrice = fixedToNumber(BigNumber.from(getDecoded[`2`]));
+    const {tokenType, maturity, strike64x64} = parseTokenId(data.longTokenId);
+    constructEvent.type = tokenType === TokenType.LongCall ? `long Call` : tokenType === TokenType.LongPut ? `long Put` : `Not Supported`
+    constructEvent.maturity = new Date(maturity.toNumber() * 1000).toDateString();
+    constructEvent.strikePrice = fixedToNumber(strike64x64);
     await http.get(
       `${endpoint}New Purchase ${constructEvent.pair} ${constructEvent.type} size: ${constructEvent.size} strike: ${constructEvent.strikePrice} maturity: ${constructEvent.maturity}`
     )
@@ -71,10 +69,10 @@ async function sendNotificationBTC(data: eventPurchase, http: any) {
       size: data.contractSize,
       pair: `WBTC/DAI`
     }
-    const getDecoded = await poolViewContract.methods.getParametersForTokenId(data.longTokenId).call()
-    constructEvent.type = getDecoded[`0`] === `4` ? `long Call` : getDecoded[`0`] === `6` ? `long Put` : `Not Supported`
-    constructEvent.maturity = new Date(getDecoded[`1`] * 1000).toDateString();
-    constructEvent.strikePrice = fixedToNumber(BigNumber.from(getDecoded[`2`]));
+    const {tokenType, maturity, strike64x64} = parseTokenId(data.longTokenId);
+    constructEvent.type = tokenType === TokenType.LongCall ? `long Call` : tokenType === TokenType.LongPut ? `long Put` : `Not Supported`
+    constructEvent.maturity = new Date(maturity.toNumber() * 1000).toDateString();
+    constructEvent.strikePrice = fixedToNumber(strike64x64);
     await http.get(
       `${endpoint}New Purchase ${constructEvent.pair} ${constructEvent.type} size: ${constructEvent.size.toLocaleString()} strike: ${constructEvent.strikePrice} maturity: ${constructEvent.maturity}`
     )

--- a/core/purchase.ts
+++ b/core/purchase.ts
@@ -2,6 +2,7 @@ import { eventForTelegram, eventPurchase } from "../models/models";
 import { fixedToNumber, parseTokenId, TokenType } from '@premia/utils'
 import { bnToNumber, bnToNumberBTC, endpoint } from "../utils/utils";
 import { envConfig } from "../config/env";
+import {BigNumber} from "ethers";
 
 
 let poolViewContract: any;
@@ -11,7 +12,7 @@ async function sendNotificationETH(data: eventPurchase, http: any) {
       size: data.contractSize,
       pair: `WETH/DAI`
     }
-    const {tokenType, maturity, strike64x64} = parseTokenId(data.longTokenId);
+    const {tokenType, maturity, strike64x64} = parseTokenId(BigNumber.from(data.longTokenId).toHexString());
     constructEvent.type = tokenType === TokenType.LongCall ? `long Call` : tokenType === TokenType.LongPut ? `long Put` : `Not Supported`
     constructEvent.maturity = new Date(maturity.toNumber() * 1000).toDateString();
     constructEvent.strikePrice = fixedToNumber(strike64x64);
@@ -40,7 +41,7 @@ async function sendNotificationLINK(data: eventPurchase, http: any) {
       size: data.contractSize,
       pair: `LINK/DAI`
     }
-    const {tokenType, maturity, strike64x64} = parseTokenId(data.longTokenId);
+    const {tokenType, maturity, strike64x64} = parseTokenId(BigNumber.from(data.longTokenId).toHexString());
     constructEvent.type = tokenType === TokenType.LongCall ? `long Call` : tokenType === TokenType.LongPut ? `long Put` : `Not Supported`
     constructEvent.maturity = new Date(maturity.toNumber() * 1000).toDateString();
     constructEvent.strikePrice = fixedToNumber(strike64x64);
@@ -69,7 +70,7 @@ async function sendNotificationBTC(data: eventPurchase, http: any) {
       size: data.contractSize,
       pair: `WBTC/DAI`
     }
-    const {tokenType, maturity, strike64x64} = parseTokenId(data.longTokenId);
+    const {tokenType, maturity, strike64x64} = parseTokenId(BigNumber.from(data.longTokenId).toHexString());
     constructEvent.type = tokenType === TokenType.LongCall ? `long Call` : tokenType === TokenType.LongPut ? `long Put` : `Not Supported`
     constructEvent.maturity = new Date(maturity.toNumber() * 1000).toDateString();
     constructEvent.strikePrice = fixedToNumber(strike64x64);


### PR DESCRIPTION
Remove unnecessary contract calls by using @premia/utils instead to parse token id.